### PR TITLE
Revert "Add coveralls.io support"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 Node.js module for website's scraping with images, css, js, etc. 
 
 [![Build Status](https://img.shields.io/travis/s0ph1e/node-website-scraper/master.svg?style=flat)](https://travis-ci.org/s0ph1e/node-website-scraper)
-[![Coverage Status](https://coveralls.io/repos/s0ph1e/node-website-scraper/badge.svg)](https://coveralls.io/r/s0ph1e/node-website-scraper)
 [![Code Climate](https://img.shields.io/codeclimate/github/s0ph1e/node-website-scraper.svg?style=flat)](https://codeclimate.com/github/s0ph1e/node-website-scraper)
 [![Version](https://img.shields.io/npm/v/website-scraper.svg?style=flat)](https://www.npmjs.org/package/website-scraper)
 [![Downloads](https://img.shields.io/npm/dm/website-scraper.svg?style=flat)](https://www.npmjs.org/package/website-scraper)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "readmeFilename": "README.md",
   "main": "index.js",
   "scripts": {
-    "test": "istanbul cover ./node_modules/mocha/bin/_mocha --report lcovonly -- -R spec && cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js && rm -rf ./coverage"
+    "test": "node_modules/mocha/bin/mocha"
   },
   "repository": {
     "type": "git",
@@ -40,8 +40,6 @@
   "devDependencies": {
     "should": "^5.0.0",
     "mocha": "^2.0.1",
-    "nock": "^1.6.0",
-    "coveralls": "^2.11.2",
-    "istanbul": "^0.3.7"
+    "nock": "^1.6.0"
   }
 }


### PR DESCRIPTION
Reverts s0ph1e/node-website-scraper#3

Remove coveralls.io support because of coveralls issues (https://github.com/lemurheavy/coveralls-public/issues/504 and https://github.com/lemurheavy/coveralls-public/issues/487)