### PR TITLE
Added ability to handle named anchors

### DIFF
--- a/lib/file-handlers/html.js
+++ b/lib/file-handlers/html.js
@@ -54,7 +54,14 @@ function loadResources (context, resource, source) {
 
 			return context.loadResource(htmlResource).then(function handleLoadedSource (loadedResource) {
 				var relativePath = utils.getRelativePath(filename, loadedResource.getFilename());
-				el.attr(source.attr, relativePath);
+				//Don't take out named anchors / hashlinks
+				//Find out if link is a named anchor and append it to the relative Path
+				//Start out with an empty string
+				var named = "";
+				if(el.attr(source.attr).charAt(0) === "#"){
+					named = el.attr(source.attr);
+				}
+				el.attr(source.attr, relativePath.concat(named));
 				return Promise.resolve();
 			});
 		}


### PR DESCRIPTION
I noticed that in recursive scraping, it didn't correctly add the named anchor links, it just changed the link to the page name.
i.e. all links with www.example.com/page.html#id would become path/to/file/page.html, not  path/to/file/page.html#id

I fixed this by concatenating the source attribute to the relative path in html.js