### PR TITLE
Remove node_modules from travis cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: node_js
 sudo: false
-cache:
-  directories:
-    - node_modules
 node_js:
   - "5.1"
   - "4.2"


### PR DESCRIPTION
Trying to fix `Error: Cannot find module` error