### PR TITLE
Fixed bug with unspecified protocol in resources on https page.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,10 +9,11 @@ function isUrl (path) {
 }
 
 function getUrl (currentUrl, path) {
-	var pathObj = url.parse(path);
-	if (isUrl(path) && !pathObj.protocol) {
-		pathObj.protocol = 'http';
-		path = url.format(pathObj);
+	var pathObject = url.parse(path);
+	if (isUrl(path) && !pathObject.protocol) {
+		var urlObject = url.parse(currentUrl);
+		pathObject.protocol = urlObject.protocol;
+		path = url.format(pathObject);
 	}
 	return url.resolve(currentUrl, path);
 }

--- a/test/unit/utils-test.js
+++ b/test/unit/utils-test.js
@@ -30,6 +30,10 @@ describe('Common utils', function () {
 			utils.getUrl('http://google.com', 'http://my.site.com/').should.be.equal('http://my.site.com/');
 			utils.getUrl('http://google.com/qwe/qwe/qwe', '//my.site.com').should.be.equal('http://my.site.com/');
 		});
+		it('should use the protocol from the url, if the path is a protocol-less url', function (){
+			utils.getUrl('http://my.site.com', '//cdn.com/library.js').should.be.equal('http://cdn.com/library.js');
+			utils.getUrl('https://my.site.com', '//cdn.com/library.js').should.be.equal('https://cdn.com/library.js');
+		});
 	});
 
 	describe('#getUnixPath(path)', function () {


### PR DESCRIPTION
- When a resource link does not have a protocol defined the protocol from the url of the containing page should be used, instead of just choosing 'http'.