### PR TITLE
Fixed promise bug.

### DIFF
--- a/lib/file-handlers/html.js
+++ b/lib/file-handlers/html.js
@@ -139,7 +139,7 @@ function loadResourcesForRule (context, resource, rule) {
 				el.attr(rule.attr, updatedAttr);
 			});
 		}
-		return Promise.reject();
+		return Promise.resolve();
 	}).get();
 
 	return utils.waitAllFulfilled(promises).then(function updateHtmlText () {


### PR DESCRIPTION
Promises should only be rejected with an Error. In this case there is no Error, but just no result.
Bluebird gives warnings when Promises are rejected without an Error.