### PR TITLE
Node 6.x.x fs.extname(undefined) call throws exception

### DIFF
--- a/lib/resource.js
+++ b/lib/resource.js
@@ -97,7 +97,7 @@ Resource.prototype.setHtmlData = function setHtmlData (data) {
 };
 
 Resource.prototype.getType = function getType () {
-	var ext = path.extname(this.filename);
+	var ext = this.filename ? path.extname(this.filename) : undefined;
 	var parent = this.parent;
 	var hasHtmlData = !_.isEmpty(this.htmlData);
 


### PR DESCRIPTION
The new Node 6.x.x throws an exception when you call fs.extname with an undefined argument.
(See https://nodejs.org/en/blog/release/v6.0.0/)

