### PR TITLE
Improved mechanism for re-using already loaded / loading resources.

### DIFF
--- a/lib/file-handlers/html.js
+++ b/lib/file-handlers/html.js
@@ -87,9 +87,9 @@ function loadImgSrcsetResource (context, parentResource, childResourceHtmlData) 
 
 				// Do not wait for loadResource here, to prevent deadlock, see scraper.waitForLoad
 				context.loadResource(childResource);
-				return null; // Prevent Bluebird warnings
 			}
-		})
+			return null; // Prevent Bluebird warnings
+		});
 	}).then(function updateSrcset () {
 		return Promise.resolve(srcset.stringify(imgScrsetParts));
 	});

--- a/lib/file-handlers/html.js
+++ b/lib/file-handlers/html.js
@@ -79,13 +79,16 @@ function loadImgSrcsetResource (context, parentResource, childResourceHtmlData) 
 		var childResourceUrl = utils.getUrl(parentResource.getUrl(), imgScrsetPart.url);
 		var childResource = parentResource.createChild(childResourceUrl);
 		childResource.setHtmlData(childResourceHtmlData);
+		
+		return context.requestResource(childResource).then(function updateSrcsetPart (respondedResource) {
+			if(respondedResource){
+				parentResource.updateChild(childResource, respondedResource);
+				imgScrsetPart.url = respondedResource.getFilename();
 
-		return context.loadResource(childResource).then(function updateSrcsetPart (loadedResource) {
-			if(loadedResource){
-				parentResource.updateChild(childResource, loadedResource);
-				imgScrsetPart.url = loadedResource.getFilename();
+				// Do not wait for loadResource here, to prevent deadlock, see scraper.waitForLoad
+				context.loadResource(childResource);
 			}
-		});
+		})
 	}).then(function updateSrcset () {
 		return Promise.resolve(srcset.stringify(imgScrsetParts));
 	});
@@ -102,24 +105,27 @@ function loadGeneralResource (context, parentResource, childResourceHtmlData) {
 	var attr = childResourceHtmlData.attributeValue;
 
 	var resourceUrl = utils.getUrl(parentResource.getUrl(), attr);
-	var htmlResource = parentResource.createChild(resourceUrl);
-	htmlResource.setHtmlData(childResourceHtmlData);
+	var childResource = parentResource.createChild(resourceUrl);
+	childResource.setHtmlData(childResourceHtmlData);
 
-	return context.loadResource(htmlResource).then(function handleLoadedSource (loadedResource) {
-		if(!loadedResource){
+	return context.requestResource(childResource).then(function handleLoadedSource (respondedResource) {
+		if(!respondedResource){
 			return attr;
 		}
-		parentResource.updateChild(htmlResource, loadedResource);
+		parentResource.updateChild(childResource, respondedResource);
 
-		var relativePath = utils.getRelativePath(parentResource.getFilename(), loadedResource.getFilename());
+		var relativePath = utils.getRelativePath(parentResource.getFilename(), respondedResource.getFilename());
 		if(context.options.prettifyUrls){
 			relativePath = relativePath.replace(context.options.defaultFilename, '');
 		}
 		var hash = utils.getHashFromUrl(attr);
 
-		if (hash && loadedResource.isHtml()) {
+		if (hash && respondedResource.isHtml()) {
 			relativePath = relativePath.concat(hash);
 		}
+
+		// Do not wait for loadResource here, to prevent deadlock, scraper.waitForLoad
+		context.loadResource(childResource);
 
 		return relativePath;
 	});

--- a/lib/file-handlers/html.js
+++ b/lib/file-handlers/html.js
@@ -87,6 +87,7 @@ function loadImgSrcsetResource (context, parentResource, childResourceHtmlData) 
 
 				// Do not wait for loadResource here, to prevent deadlock, see scraper.waitForLoad
 				context.loadResource(childResource);
+				return null; // Prevent Bluebird warnings
 			}
 		})
 	}).then(function updateSrcset () {

--- a/lib/filename-generators/by-type.js
+++ b/lib/filename-generators/by-type.js
@@ -3,8 +3,8 @@ var path = require('path');
 var utils = require('../utils.js');
 var defaultExtensions = require('../config/resource-extensions-by-type');
 
-module.exports = function generateFilename (resource, options, loadedResources) {
-	var occupiedFilenames = getOccupiedFilenames(loadedResources, options);
+module.exports = function generateFilename (resource, options, occupiedFileNames) {
+	var occupiedNames = getSubDirectoryNames(options).concat(occupiedFileNames);
 
 	var filename = getFilenameForResource(resource, options);
 	var extension = utils.getFilenameExtension(filename);
@@ -14,7 +14,7 @@ module.exports = function generateFilename (resource, options, loadedResources) 
 	var basename = path.basename(filename, extension);
 	var index = 1;
 
-	while (_.includes(occupiedFilenames, currentFilename)) {
+	while (_.includes(occupiedNames, currentFilename)) {
 		currentFilename = path.join(directory, basename + '_' + index + extension);
 		index++;
 	}
@@ -37,10 +37,8 @@ function getFilenameForResource (resource, options) {
 	return filename;
 }
 
-function getOccupiedFilenames (loadedResources, options) {
-	var subdirectories = _.map(options.subdirectories, function getDirectory (directory) { return directory.directory; });
-	var loadedFiles = _.map(loadedResources, function getFileName (resource) { return resource.getFilename(); });
-	return subdirectories.concat(loadedFiles);
+function getSubDirectoryNames (options) {
+	return _.map(options.subdirectories, function getDirectory (directory) { return directory.directory; });
 }
 
 function getDirectoryByExtension (extension, options) {

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -193,6 +193,10 @@ Scraper.prototype.load = function load () {
 	return self.waitForLoad(0);
 };
 
+// Returns a promise which gets resolved when all resources are loaded.
+// Determines whether loading is done by:
+// 1. Waiting until all loadedResourcePromises are resolved.
+// 2. Recursing itself if any new loadedResourcePromises (promises for the loading of childResources) where added during this time. If not, loading is done.
 Scraper.prototype.waitForLoad = function waitForLoad (previousCount) {
 	var self = this;
 	var count = _.size(self.loadedResourcePromises);

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -107,9 +107,9 @@ Scraper.prototype.loadResource = function loadResource (resource) {
 
 	loadedResourcePromise = respondedResourcePromise.then(function handleResponse (resource) {
 		return Promise.resolve()
-			.then(function handleFile () {
-				var handleFile = self.getResourceHandler(resource);
-				return handleFile(self, resource);
+			.then(function handleResource () {
+				var resourceHandler = self.getResourceHandler(resource);
+				return resourceHandler(self, resource);
 			}).then(function fileHandled () {
 				var filename = path.join(self.options.directory, resource.getFilename());
 				var text = resource.getText();

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -49,12 +49,12 @@ Scraper.prototype.addLoadedResource = function addLoadedResource (resource) {
 	this.loadedResources.push(resource);
 };
 
-Scraper.prototype.addRespondedResourcePromise = function addRequestedResourcePromise (url, promise) {
+Scraper.prototype.addRespondedResourcePromise = function addRespondedResourcePromise (url, promise) {
 	url = normalizeUrl(url);
 	this.respondedResourcePromises[url] = promise;
 };
 
-Scraper.prototype.getRespondedResourcePromise = function getRequestedResourcePromise (url) {
+Scraper.prototype.getRespondedResourcePromise = function getRespondedResourcePromise (url) {
 	url = normalizeUrl(url);
 	return this.respondedResourcePromises[url];
 };
@@ -133,9 +133,9 @@ Scraper.prototype.requestResource = function requestResource (resource) {
 		return Promise.resolve(null);
 	}
 
-	var repondedResourcePromise = self.getRespondedResourcePromise(url);
-	if(repondedResourcePromise) {
-		return repondedResourcePromise;
+	var respondedResourcePromise = self.getRespondedResourcePromise(url);
+	if(respondedResourcePromise) {
+		return respondedResourcePromise;
 	}
 
 	var promise = self.makeRequest(url).then(function requestCompleted (data) {
@@ -190,7 +190,7 @@ Scraper.prototype.load = function load () {
 	_.forEach(self.originalResources, function loadResource (resource) {
 		self.loadResource(resource);
 	});
-	return self.waitForLoad();
+	return self.waitForLoad(0);
 };
 
 Scraper.prototype.waitForLoad = function waitForLoad (previousCount) {

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -14,7 +14,7 @@ var Resource = require('./resource');
 
 var getFilenameGenerator = require('./filename-generators/filename-generator-getter');
 var makeRequest = require('./request');
-var compareUrls = require('compare-urls');
+var normalizeUrl = require('normalize-url');
 
 var loadHtml = require('./file-handlers/html');
 var loadCss = require('./file-handlers/css');
@@ -26,7 +26,8 @@ function loadHtmlAndCss (context, po) {
 
 function Scraper (options) {
 	this.originalResources = [];
-	this.loadedResources = [];
+	this.occupiedFileNames = [];
+	this.requestedResourcePromises = {};
 
 	this.options = _.extend({}, defaults, options);
 	this.options.request = _.extend({}, defaults.request, options.request);
@@ -34,14 +35,22 @@ function Scraper (options) {
 	this.options.filenameGenerator = getFilenameGenerator(this.options.filenameGenerator);
 }
 
-Scraper.prototype.getLoadedResource = function getLoadedResource (resource) {
-	return _.find(this.loadedResources, function checkUrlsEqual (lr) {
-		return compareUrls(resource.getUrl(), lr.getUrl());
-	});
+Scraper.prototype.addOccupiedFileName = function addOccupiedFileName (filename) {
+	this.occupiedFileNames.push(filename);
 };
 
-Scraper.prototype.addLoadedResource = function addLoadedResource (resource) {
-	this.loadedResources.push(resource);
+Scraper.prototype.getOccupiedFileNames = function getOccupiedFileNames () {
+	return this.occupiedFileNames;
+};
+
+Scraper.prototype.addRequestedResourcePromise = function addRequestedResourcePromise (url, promise) {
+	url = normalizeUrl(url);
+	this.requestedResourcePromises[url] = promise;
+};
+
+Scraper.prototype.getRequestedResourcePromise = function getRequestedResourcePromise (url) {
+	url = normalizeUrl(url);
+	return this.requestedResourcePromises[url];
 };
 
 Scraper.prototype.getHtmlSources = function getHtmlSources () {
@@ -63,36 +72,35 @@ Scraper.prototype.getResourceHandler = function getHandler (resource) {
 
 Scraper.prototype.loadResource = function loadResource (resource) {
 	var self = this;
+	var url = resource.getUrl();
 
-	if(!self.options.urlFilter(resource.url)){
+	if(!self.options.urlFilter(url)){
 		return Promise.resolve(null);
 	}
 
-	// try to find already loaded
-	var loaded = self.getLoadedResource(resource);
-
-	if (!loaded) {
-		var url = resource.getUrl();
-		var filename = self.options.filenameGenerator(resource, self.options, self.loadedResources);
-		resource.setFilename(filename);
-
-		self.addLoadedResource(resource);
-
-		// Request -> processing -> save to fs
-		return self.makeRequest(url).then(function requestCompleted (data) {
-			resource.setUrl(data.url);  // Url may be changed in redirects
-			resource.setText(data.body);
-			var handleFile = self.getResourceHandler(resource);
-			return handleFile(self, resource);
-		}).then(function fileHandled () {
-			var filename = path.join(self.options.directory, resource.getFilename());
-			var text = resource.getText();
-			return outputFileAsync(filename, text, { encoding: 'binary' });
-		}).then(function fileSaved () {
-			return Promise.resolve(resource);
-		});
+	var loaded = self.getRequestedResourcePromise(url);
+	if(loaded){
+		return loaded;
 	}
-	return Promise.resolve(loaded);
+
+	var filename = self.options.filenameGenerator(resource, self.options, self.getOccupiedFileNames());
+	resource.setFilename(filename);
+	self.addOccupiedFileName(filename);
+	var promise = self.makeRequest(url).then(function requestCompleted (data) {
+		resource.setUrl(data.url);  // Url may be changed in redirects
+		self.addRequestedResourcePromise(data.url, promise);
+		resource.setText(data.body);
+		var handleFile = self.getResourceHandler(resource);
+		return handleFile(self, resource);
+	}).then(function fileHandled () {
+		var filename = path.join(self.options.directory, resource.getFilename());
+		var text = resource.getText();
+		return outputFileAsync(filename, text, { encoding: 'binary' });
+	}).then(function fileSaved () {
+		return Promise.resolve(resource);
+	});
+	self.addRequestedResourcePromise(url, promise);
+	return promise;
 };
 
 Scraper.prototype.validate = function validate () {
@@ -133,7 +141,7 @@ Scraper.prototype.load = function load () {
 };
 
 Scraper.prototype.errorCleanup = function errorCleanup (error) {
-	if (!_.isEmpty(this.loadedResources)) {
+	if (!_.isEmpty(this.requestedResourcePromises)) {
 		fs.removeSync(this.options.directory);
 	}
 	throw error;

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -27,7 +27,9 @@ function loadHtmlAndCss (context, po) {
 function Scraper (options) {
 	this.originalResources = [];
 	this.occupiedFileNames = [];
-	this.requestedResourcePromises = {};
+	this.loadedResources = [];
+	this.respondedResourcePromises = {};
+	this.loadedResourcePromises = {};
 
 	this.options = _.extend({}, defaults, options);
 	this.options.request = _.extend({}, defaults.request, options.request);
@@ -43,14 +45,28 @@ Scraper.prototype.getOccupiedFileNames = function getOccupiedFileNames () {
 	return this.occupiedFileNames;
 };
 
-Scraper.prototype.addRequestedResourcePromise = function addRequestedResourcePromise (url, promise) {
-	url = normalizeUrl(url);
-	this.requestedResourcePromises[url] = promise;
+Scraper.prototype.addLoadedResource = function addLoadedResource (resource) {
+	this.loadedResources.push(resource);
 };
 
-Scraper.prototype.getRequestedResourcePromise = function getRequestedResourcePromise (url) {
+Scraper.prototype.addRespondedResourcePromise = function addRequestedResourcePromise (url, promise) {
 	url = normalizeUrl(url);
-	return this.requestedResourcePromises[url];
+	this.respondedResourcePromises[url] = promise;
+};
+
+Scraper.prototype.getRespondedResourcePromise = function getRequestedResourcePromise (url) {
+	url = normalizeUrl(url);
+	return this.respondedResourcePromises[url];
+};
+
+Scraper.prototype.addLoadedResourcePromise = function addLoadedResourcePromise (url, promise) {
+	url = normalizeUrl(url);
+	this.loadedResourcePromises[url] = promise;
+};
+
+Scraper.prototype.getLoadedResourcePromise = function getLoadedResourcePromise (url) {
+	url = normalizeUrl(url);
+	return this.loadedResourcePromises[url];
 };
 
 Scraper.prototype.getHtmlSources = function getHtmlSources () {
@@ -62,11 +78,15 @@ Scraper.prototype.getResourceHandler = function getHandler (resource) {
 	var depth = resource.getDepth();
 	var depthGreaterThanMax = self.options.maxDepth && depth >= self.options.maxDepth;
 
-	switch (true) {
-		case depthGreaterThanMax: return _.noop;
-		case resource.isCss(): return loadCss;
-		case resource.isHtml(): return loadHtmlAndCss;
-		default: return _.noop;
+	switch(true) {
+	case depthGreaterThanMax:
+		return _.noop;
+	case resource.isCss():
+		return loadCss;
+	case resource.isHtml():
+		return loadHtmlAndCss;
+	default:
+		return _.noop;
 	}
 };
 
@@ -74,22 +94,18 @@ Scraper.prototype.loadResource = function loadResource (resource) {
 	var self = this;
 	var url = resource.getUrl();
 
-	if(!self.options.urlFilter(url)){
+	if(!self.options.urlFilter(url)) {
 		return Promise.resolve(null);
 	}
 
-	var loaded = self.getRequestedResourcePromise(url);
-	if(loaded){
-		return loaded;
+	var loadedResourcePromise = self.getLoadedResourcePromise(url);
+	if(loadedResourcePromise) {
+		return loadedResourcePromise;
 	}
 
-	var filename = self.options.filenameGenerator(resource, self.options, self.getOccupiedFileNames());
-	resource.setFilename(filename);
-	self.addOccupiedFileName(filename);
-	var promise = self.makeRequest(url).then(function requestCompleted (data) {
-		resource.setUrl(data.url);  // Url may be changed in redirects
-		self.addRequestedResourcePromise(data.url, promise);
-		resource.setText(data.body);
+	var respondedResourcePromise = self.requestResource(resource);
+
+	loadedResourcePromise = respondedResourcePromise.then(function handleResponse () {
 		var handleFile = self.getResourceHandler(resource);
 		return handleFile(self, resource);
 	}).then(function fileHandled () {
@@ -97,9 +113,42 @@ Scraper.prototype.loadResource = function loadResource (resource) {
 		var text = resource.getText();
 		return outputFileAsync(filename, text, { encoding: 'binary' });
 	}).then(function fileSaved () {
-		return Promise.resolve(resource);
+		self.addLoadedResourcePromise(resource.getUrl(), loadedResourcePromise);
+		self.addLoadedResource(resource);
+		return resource;
 	});
-	self.addRequestedResourcePromise(url, promise);
+	self.addLoadedResourcePromise(url, loadedResourcePromise);
+
+	return loadedResourcePromise;
+};
+
+Scraper.prototype.requestResource = function requestResource (resource) {
+	var self = this;
+	var url = resource.getUrl();
+
+	if(!self.options.urlFilter(url)) {
+		return Promise.resolve(null);
+	}
+
+	var repondedResourcePromise = self.getRespondedResourcePromise(url);
+	if(repondedResourcePromise) {
+		return repondedResourcePromise;
+	}
+
+	var filename = self.options.filenameGenerator(resource, self.options, self.getOccupiedFileNames());
+	resource.setFilename(filename);
+	self.addOccupiedFileName(filename);
+
+	var promise = self.makeRequest(url).then(function requestCompleted (data) {
+		// Url may be changed in redirects
+		resource.setUrl(data.url);
+		self.addRespondedResourcePromise(data.url, promise);
+
+		resource.setText(data.body);
+		return resource;
+	});
+	self.addRespondedResourcePromise(url, promise);
+
 	return promise;
 };
 
@@ -126,7 +175,7 @@ Scraper.prototype.prepare = function prepare () {
 		return new Resource(url, filename);
 	});
 
-	if (self.options.recursive) {
+	if(self.options.recursive) {
 		self.options.sources = _.union(self.options.sources, recursiveSources);
 	}
 
@@ -135,13 +184,29 @@ Scraper.prototype.prepare = function prepare () {
 
 Scraper.prototype.load = function load () {
 	var self = this;
-	return Promise.map(self.originalResources, function loadResource (resource) {
-		return self.loadResource(resource);
+	_.forEach(self.originalResources, function loadResource (resource) {
+		self.loadResource(resource);
 	});
+	return self.waitForLoad();
+};
+
+Scraper.prototype.waitForLoad = function waitForLoad (previousCount) {
+	var self = this;
+	var count = _.size(self.loadedResourcePromises);
+	if(count === previousCount) {
+		return Promise.all(_.map(self.originalResources, function (resource) {
+			return self.getLoadedResourcePromise(resource.getUrl());
+		}));
+	}
+	else{
+		return Promise
+			.all(_.toArray(self.loadedResourcePromises))
+			.then(self.waitForLoad.bind(self, count));
+	}
 };
 
 Scraper.prototype.errorCleanup = function errorCleanup (error) {
-	if (!_.isEmpty(this.requestedResourcePromises)) {
+	if (!_.isEmpty(this.loadedResources)) {
 		fs.removeSync(this.options.directory);
 	}
 	throw error;

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -138,13 +138,13 @@ Scraper.prototype.requestResource = function requestResource (resource) {
 		return repondedResourcePromise;
 	}
 
-	var filename = self.options.filenameGenerator(resource, self.options, self.getOccupiedFileNames());
-	resource.setFilename(filename);
-	self.addOccupiedFileName(filename);
-
 	var promise = self.makeRequest(url).then(function requestCompleted (data) {
 		// Url may be changed in redirects
 		resource.setUrl(data.url);
+		
+		var filename = self.options.filenameGenerator(resource, self.options, self.getOccupiedFileNames());
+		resource.setFilename(filename);
+		self.addOccupiedFileName(filename);
 		self.addRespondedResourcePromise(data.url, promise);
 
 		resource.setText(data.body);

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -105,17 +105,20 @@ Scraper.prototype.loadResource = function loadResource (resource) {
 
 	var respondedResourcePromise = self.requestResource(resource);
 
-	loadedResourcePromise = respondedResourcePromise.then(function handleResponse () {
-		var handleFile = self.getResourceHandler(resource);
-		return handleFile(self, resource);
-	}).then(function fileHandled () {
-		var filename = path.join(self.options.directory, resource.getFilename());
-		var text = resource.getText();
-		return outputFileAsync(filename, text, { encoding: 'binary' });
-	}).then(function fileSaved () {
-		self.addLoadedResourcePromise(resource.getUrl(), loadedResourcePromise);
-		self.addLoadedResource(resource);
-		return resource;
+	loadedResourcePromise = respondedResourcePromise.then(function handleResponse (resource) {
+		return Promise.resolve()
+			.then(function handleFile () {
+				var handleFile = self.getResourceHandler(resource);
+				return handleFile(self, resource);
+			}).then(function fileHandled () {
+				var filename = path.join(self.options.directory, resource.getFilename());
+				var text = resource.getText();
+				return outputFileAsync(filename, text, { encoding: 'binary' });
+			}).then(function fileSaved () {
+				self.addLoadedResourcePromise(resource.getUrl(), loadedResourcePromise);
+				self.addLoadedResource(resource);
+				return resource;
+			});
 	});
 	self.addLoadedResourcePromise(url, loadedResourcePromise);
 

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -79,14 +79,14 @@ Scraper.prototype.getResourceHandler = function getHandler (resource) {
 	var depthGreaterThanMax = self.options.maxDepth && depth >= self.options.maxDepth;
 
 	switch(true) {
-	case depthGreaterThanMax:
-		return _.noop;
-	case resource.isCss():
-		return loadCss;
-	case resource.isHtml():
-		return loadHtmlAndCss;
-	default:
-		return _.noop;
+		case depthGreaterThanMax:
+			return _.noop;
+		case resource.isCss():
+			return loadCss;
+		case resource.isHtml():
+			return loadHtmlAndCss;
+		default:
+			return _.noop;
 	}
 };
 
@@ -194,11 +194,10 @@ Scraper.prototype.waitForLoad = function waitForLoad (previousCount) {
 	var self = this;
 	var count = _.size(self.loadedResourcePromises);
 	if(count === previousCount) {
-		return Promise.all(_.map(self.originalResources, function (resource) {
+		return Promise.all(_.map(self.originalResources, function getLoadedResource (resource) {
 			return self.getLoadedResourcePromise(resource.getUrl());
 		}));
-	}
-	else{
+	} else{
 		return Promise
 			.all(_.toArray(self.loadedResourcePromises))
 			.then(self.waitForLoad.bind(self, count));

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
   "dependencies": {
     "bluebird": "^3.0.1",
     "cheerio": "0.20.0",
-    "compare-urls": "^1.0.0",
     "css-url-parser": "^1.0.0",
     "fs-extra": "^0.30.0",
     "lodash": "^4.11.1",
+    "normalize-url": "^1.5.3",
     "request": "^2.42.0",
     "srcset": "^1.0.0"
   },

--- a/test/unit/file-name-generators/by-type-test.js
+++ b/test/unit/file-name-generators/by-type-test.js
@@ -18,34 +18,34 @@ describe('byTypeFilenameGenerator', function() {
 
     it('should return resource filename', function() {
         var r = new Resource('http://example.com/a.png', 'b.png');
-        var filename = byTypeFilenameGenerator(r, s.options, s.loadedResources);
+        var filename = byTypeFilenameGenerator(r, s.options, s.occupiedFileNames);
         filename.should.be.eql('b.png');
     });
 
     it('should return url-based filename if resource has no filename', function() {
         var r = new Resource('http://example.com/a.png', '');
-        var filename = byTypeFilenameGenerator(r, s.options, s.loadedResources);
+        var filename = byTypeFilenameGenerator(r, s.options, s.occupiedFileNames);
         filename.should.be.eql('a.png');
     });
 
     it('should add missed extensions for html resources', function () {
         var r = new Resource('http://example.com/about', '');
         r.getType = sinon.stub().returns('html');
-        var filename = byTypeFilenameGenerator(r, s.options, s.loadedResources);
+        var filename = byTypeFilenameGenerator(r, s.options, s.occupiedFileNames);
         filename.should.be.eql('about.html');
     });
 
     it('should add missed extensions for css resources', function () {
         var r = new Resource('http://example.com/css', '');
         r.getType = sinon.stub().returns('css');
-        var filename = byTypeFilenameGenerator(r, s.options, s.loadedResources);
+        var filename = byTypeFilenameGenerator(r, s.options, s.occupiedFileNames);
         filename.should.be.eql('css.css');
     });
 
     it('should not add missed extensions for other resources', function () {
         var r = new Resource('http://1.gravatar.com/avatar/4d63e4a045c7ff22accc33dc08442f86?s=140&amp;d=%2Fwp-content%2Fuploads%2F2015%2F05%2FGood-JOb-150x150.jpg&amp;r=g', '');
         r.getType = sinon.stub().returns('home');
-        var filename = byTypeFilenameGenerator(r, s.options, s.loadedResources);
+        var filename = byTypeFilenameGenerator(r, s.options, s.occupiedFileNames);
         filename.should.be.eql('4d63e4a045c7ff22accc33dc08442f86');
     });
 
@@ -55,7 +55,7 @@ describe('byTypeFilenameGenerator', function() {
         ];
 
         var r = new Resource('http://example.com/a.png');
-        var filename = byTypeFilenameGenerator(r, s.options, s.loadedResources);
+        var filename = byTypeFilenameGenerator(r, s.options, s.occupiedFileNames);
         filename.should.be.eql('img/a.png');
     });
 
@@ -63,12 +63,12 @@ describe('byTypeFilenameGenerator', function() {
         var r1 = new Resource('http://first-example.com/a.png');
         var r2 = new Resource('http://second-example.com/a.png');
 
-        var f1 = byTypeFilenameGenerator(r1, s.options, s.loadedResources);
+        var f1 = byTypeFilenameGenerator(r1, s.options, s.occupiedFileNames);
         f1.should.be.eql('a.png');
         r1.setFilename(f1);
-        s.addLoadedResource(r1);
+        s.addOccupiedFileName(r1.getFilename());
 
-        var f2 = byTypeFilenameGenerator(r2, s.options, s.loadedResources);
+        var f2 = byTypeFilenameGenerator(r2, s.options, s.occupiedFileNames);
         f2.should.be.not.eql('a.png');
     });
 
@@ -78,23 +78,23 @@ describe('byTypeFilenameGenerator', function() {
         var r3 = new Resource('http://third-example.com/a.png');
         var r4 = new Resource('http://fourth-example.com/a.png');
 
-        var f1 = byTypeFilenameGenerator(r1, s.options, s.loadedResources);
+        var f1 = byTypeFilenameGenerator(r1, s.options, s.occupiedFileNames);
         f1.should.be.eql('a.png');
         r1.setFilename(f1);
-        s.addLoadedResource(r1);
+        s.addOccupiedFileName(r1.getFilename());
 
-        var f2 = byTypeFilenameGenerator(r2, s.options, s.loadedResources);
+        var f2 = byTypeFilenameGenerator(r2, s.options, s.occupiedFileNames);
         f2.should.be.not.eql(r1.getFilename());
         r2.setFilename(f2);
-        s.addLoadedResource(r2);
+        s.addOccupiedFileName(r2.getFilename());
 
-        var f3 = byTypeFilenameGenerator(r3, s.options, s.loadedResources);
+        var f3 = byTypeFilenameGenerator(r3, s.options, s.occupiedFileNames);
         f3.should.be.not.eql(r1.getFilename());
         f3.should.be.not.eql(r2.getFilename());
         r3.setFilename(f3);
-        s.addLoadedResource(r3);
+        s.addOccupiedFileName(r3.getFilename());
 
-        var f4 = byTypeFilenameGenerator(r4, s.options, s.loadedResources);
+        var f4 = byTypeFilenameGenerator(r4, s.options, s.occupiedFileNames);
         f4.should.be.not.eql(r1.getFilename());
         f4.should.be.not.eql(r2.getFilename());
         f4.should.be.not.eql(r3.getFilename());

--- a/test/unit/scraper-test.js
+++ b/test/unit/scraper-test.js
@@ -257,7 +257,8 @@ describe('Scraper', function () {
 			});
 
 			s.prepare().then(function() {
-				s.addLoadedResource(new Resource('http://some-resource.com'));
+				var resource = new Resource('http://some-resource.com');
+				s.addRequestedResourcePromise(resource.getUrl(), resource);
 				fs.existsSync(testDirname).should.be.eql(true);
 				return s.errorCleanup();
 			}).then(function() {
@@ -295,7 +296,7 @@ describe('Scraper', function () {
 
 			s.prepare().then(function() {
 				var a = new Resource('http://first-resource.com');
-				var loaded = s.getLoadedResource(a);
+				var loaded = s.getRequestedResourcePromise(a.getUrl());
 				should(loaded).be.empty();
 				done();
 			}).catch(done);
@@ -309,14 +310,14 @@ describe('Scraper', function () {
 
 			s.prepare().then(function() {
 				var a = new Resource('http://first-resource.com');
-				s.addLoadedResource(a);
+				s.addRequestedResourcePromise(a.getUrl(), a);
 
 				var b = new Resource('http://first-resource.com');
 				var c = new Resource('http://first-resource.com/');
 				var d = new Resource('http://first-resource.com?');
-				should(s.getLoadedResource(b)).be.equal(a);
-				should(s.getLoadedResource(c)).be.equal(a);
-				should(s.getLoadedResource(d)).be.equal(a);
+				should(s.getRequestedResourcePromise(b.getUrl())).be.equal(a);
+				should(s.getRequestedResourcePromise(c.getUrl())).be.equal(a);
+				should(s.getRequestedResourcePromise(d.getUrl())).be.equal(a);
 
 				done();
 			}).catch(done);

--- a/test/unit/scraper-test.js
+++ b/test/unit/scraper-test.js
@@ -258,7 +258,7 @@ describe('Scraper', function () {
 
 			s.prepare().then(function() {
 				var resource = new Resource('http://some-resource.com');
-				s.addRequestedResourcePromise(resource.getUrl(), resource);
+				s.addLoadedResource(resource);
 				fs.existsSync(testDirname).should.be.eql(true);
 				return s.errorCleanup();
 			}).then(function() {
@@ -296,7 +296,7 @@ describe('Scraper', function () {
 
 			s.prepare().then(function() {
 				var a = new Resource('http://first-resource.com');
-				var loaded = s.getRequestedResourcePromise(a.getUrl());
+				var loaded = s.getLoadedResourcePromise(a.getUrl());
 				should(loaded).be.empty();
 				done();
 			}).catch(done);
@@ -310,14 +310,14 @@ describe('Scraper', function () {
 
 			s.prepare().then(function() {
 				var a = new Resource('http://first-resource.com');
-				s.addRequestedResourcePromise(a.getUrl(), a);
+				s.addLoadedResourcePromise(a.getUrl(), a);
 
 				var b = new Resource('http://first-resource.com');
 				var c = new Resource('http://first-resource.com/');
 				var d = new Resource('http://first-resource.com?');
-				should(s.getRequestedResourcePromise(b.getUrl())).be.equal(a);
-				should(s.getRequestedResourcePromise(c.getUrl())).be.equal(a);
-				should(s.getRequestedResourcePromise(d.getUrl())).be.equal(a);
+				should(s.getLoadedResourcePromise(b.getUrl())).be.equal(a);
+				should(s.getLoadedResourcePromise(c.getUrl())).be.equal(a);
+				should(s.getLoadedResourcePromise(d.getUrl())).be.equal(a);
 
 				done();
 			}).catch(done);


### PR DESCRIPTION
1. `requestResource` executes the request for the resource, and saves the response. Processing the same resource multiple times is prevented by maintaining `respondedResourcePromises`.
2. `loadResource` calls `requestResource` and saves the resource to disk. Processing the same resource multiple times is prevented by maintaining `loadedResourcePromises`.
3. To prevent deadlocks `file-handlers/html.js` only waits for `requestResource`, not for `loadResource`.
4. To determine when the scraper is finished `loadedResourcePromises` is used.