### PR TITLE
validate if existing directory is empty

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -5,6 +5,7 @@ var existsAsync = Promise.promisify(fs.stat);
 var outputFileAsync = Promise.promisify(fs.outputFile);
 var ensureDirAsync = Promise.promisify(fs.ensureDir);
 
+var emptyDir = require('empty-dir');
 var path = require('path');
 var _ = require('lodash');
 
@@ -98,6 +99,9 @@ Scraper.prototype.loadResource = function loadResource (resource) {
 Scraper.prototype.validate = function validate () {
 	var dir = this.options.directory;
 	return existsAsync(dir).then(function handleDirectoryExist () {
+		if (emptyDir.sync(dir)) {
+			return Promise.resolve();
+		}
 		return Promise.reject(new Error('Path ' + dir + ' exists'));
 	}, function handleDirectoryNotExist () {
 		return Promise.resolve();

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "cheerio": "0.20.0",
     "compare-urls": "^1.0.0",
     "css-url-parser": "^1.0.0",
+    "empty-dir": "^0.2.0",
     "fs-extra": "^0.30.0",
     "lodash": "^4.11.1",
     "request": "^2.42.0",


### PR DESCRIPTION
This will allow the scraping to proceed as long as the existing target directory is empty.