### PR TITLE
Fix for too long filenames and updates them in the HTML

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -226,7 +226,7 @@ Scraper.prototype.waitForLoad = function waitForLoad (previousCount) {
 
 ////////////////////////////////////////////////////////////////////////////////
 // @change - use to replace the too long name with a shorter name
-Scraper.prototype.updateDependencies = function updateDependencies (error) {
+Scraper.prototype.updateDependencies = function updateDependencies () {
 	var dirfilename = this.options.directory+"/"+defaults.defaultFilename;
 	this.overrideFiles.forEach(function(obj) {
 		fs.readFileSync(dirfilename, 'utf8', function (err,data) {
@@ -235,7 +235,9 @@ Scraper.prototype.updateDependencies = function updateDependencies (error) {
 			}
 			var result = data.replace(/obj.origin/g, obj.src);
 			fs.writeFileSync(dirfilename, result, 'utf8', function (err) {
-				 if (err) return console.log(err);
+				 if (err) {
+				 	return console.log(err);	
+				 }
 			});
 		});
 	});

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -30,6 +30,9 @@ function Scraper (options) {
 	this.loadedResources = [];
 	this.respondedResourcePromises = {};
 	this.loadedResourcePromises = {};
+	////////////////////////////////////////////////////////////////////////////
+	this.overrideFiles = []; // @change - use this to store the too-long files and update html
+	////////////////////////////////////////////////////////////////////////////
 
 	this.options = _.extend({}, defaults, options);
 	this.options.request = _.extend({}, defaults.request, options.request);
@@ -142,7 +145,17 @@ Scraper.prototype.requestResource = function requestResource (resource) {
 		// Url may be changed in redirects
 		resource.setUrl(data.url);
 		
+		////////////////////////////////////////////////////////////////////////////
+		//@change - when files are too long, need to shorten the filename and update html file e.g. http://www.aplusi.com/ using typekit (e.g. most squarespace sites)
 		var filename = self.options.filenameGenerator(resource, self.options, self.getOccupiedFileNames());
+		if (filename.length>255) {
+			var toolongfilename = filename;
+			filename = filename.substring(0,252)+filename.slice(-5);
+			//keep track of changes and will replace string in html
+			self.overrideFiles.push({origin: toolongfilename, src:filename});
+		}
+		////////////////////////////////////////////////////////////////////////////
+
 		resource.setFilename(filename);
 		self.addOccupiedFileName(filename);
 		self.addRespondedResourcePromise(data.url, promise);
@@ -211,6 +224,24 @@ Scraper.prototype.waitForLoad = function waitForLoad (previousCount) {
 	}
 };
 
+////////////////////////////////////////////////////////////////////////////////
+// @change - use to replace the too long name with a shorter name
+Scraper.prototype.updateDependencies = function updateDependencies (error) {
+	var dirfilename = this.options.directory+"/"+defaults.defaultFilename;
+	this.overrideFiles.forEach(function(obj) {
+		fs.readFileSync(dirfilename, 'utf8', function (err,data) {
+			if (err) {
+				return console.log(err);
+			}
+			var result = data.replace(/obj.origin/g, obj.src);
+			fs.writeFileSync(dirfilename, result, 'utf8', function (err) {
+				 if (err) return console.log(err);
+			});
+		});
+	});
+};
+////////////////////////////////////////////////////////////////////////////////
+
 Scraper.prototype.errorCleanup = function errorCleanup (error) {
 	if (!_.isEmpty(this.loadedResources)) {
 		fs.removeSync(this.options.directory);
@@ -224,6 +255,7 @@ Scraper.prototype.scrape = function scrape (callback) {
 		.then(self.validate)
 		.then(self.prepare)
 		.then(self.load)
+		.then(self.updateDependencies) // @change - update HTML file with shorter name dependencies
 		.catch(self.errorCleanup)
 		.asCallback(callback);
 };


### PR DESCRIPTION
There are a few sites that I came across that throw a too long filename error. I grab the first ~250 characters and shorten the filename. I then store both the too long and shorten name and update the HTML. 
 e.g. http://www.aplusi.com