### PR TITLE
Call loadResource only for responded resources

### DIFF
--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -157,8 +157,10 @@ Scraper.prototype.load = function load () {
 	return self.fsAdapter.createDirectory().then(function loadAllResources () {
 		return Promise.map(self.originalResources, function loadResource (originalResource) {
 			return self.requestResource(originalResource).then(function receivedResponse (resOriginalResource) {
-				// Do not wait for loadResource here, to prevent deadlock, scraper.waitForLoad
-				self.loadResource(resOriginalResource);
+				if (resOriginalResource) {
+					// Do not wait for loadResource here, to prevent deadlock, scraper.waitForLoad
+					self.loadResource(resOriginalResource);
+				}
 			});
 		}).then(self.waitForLoad.bind(self));
 	});


### PR DESCRIPTION
Responded resource may be `null` due to request error, `urlFilter` or `maxDepth` options or if it was loaded earlier