### PR TITLE
Add headers to the originalResources collection before resolving

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -24,7 +24,8 @@ function makeRequest (options, url, referer) {
 		return {
 			url: data.request.href,
 			mimeType: getMimeType(data.headers['content-type']),
-			body: data.body
+			body: data.body,
+			headers:data.headers
 		};
 	});
 }

--- a/lib/resource.js
+++ b/lib/resource.js
@@ -88,4 +88,12 @@ Resource.prototype.setSaved = function setSaved () {
 	this.saved = true;
 };
 
+Resource.prototype.setHeaders = function setHeaders (headers) {
+	this.headers = headers;
+};
+
+Resource.prototype.getHeaders = function getHeaders () {
+	return this.headers;
+};
+
 module.exports = Resource;

--- a/lib/scraper.js
+++ b/lib/scraper.js
@@ -105,6 +105,7 @@ Scraper.prototype.createNewRequest = function createNewRequest (resource) {
 			}
 
 			resource.setText(responseData.body);
+			resource.setHeaders(responseData.headers);
 			self.loadResource(resource); // Add resource to list for future downloading, see Scraper.waitForLoad
 			return resource;
 		}).catch(function handleError (err) {
@@ -162,6 +163,13 @@ Scraper.prototype.waitForLoad = function waitForLoad () {
 			.then(self.waitForLoad.bind(self));
 	}
 	logger.info('downloading is finished successfully');
+    // Add any loaded headers to the original resources
+	self.originalResources.forEach((resource)=> {
+		const loaded = self.loadedResources.get(resource.getUrl());
+		if (loaded) {
+			resource.setHeaders(loaded.getHeaders());
+		}
+	});
 	return Promise.resolve(self.originalResources);
 };
 


### PR DESCRIPTION
We find it very useful to save the returned headers along with the web page.