### PR TITLE
Add .mp4 files to a directory

### DIFF
--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -40,6 +40,7 @@ const config = {
 		{ directory: 'images', extensions: ['.png', '.jpg', '.jpeg', '.gif', '.webp'] },
 		{ directory: 'js', extensions: ['.js'] },
 		{ directory: 'css', extensions: ['.css'] },
+		{ directory: 'media', extensions: ['.mp4'] },
 		{ directory: 'fonts', extensions: ['.ttf', '.woff', '.woff2', '.eot', '.svg'] }
 	],
 	request: {

--- a/lib/config/defaults.js
+++ b/lib/config/defaults.js
@@ -40,7 +40,7 @@ const config = {
 		{ directory: 'images', extensions: ['.png', '.jpg', '.jpeg', '.gif', '.webp'] },
 		{ directory: 'js', extensions: ['.js'] },
 		{ directory: 'css', extensions: ['.css'] },
-		{ directory: 'media', extensions: ['.mp4'] },
+		{ directory: 'media', extensions: ['.mp4', '.mp3', '.ogg', '.webm', '.mov', '.wave', '.wav', '.flac'] },
 		{ directory: 'fonts', extensions: ['.ttf', '.woff', '.woff2', '.eot', '.svg'] }
 	],
 	request: {


### PR DESCRIPTION
Example tag: `<source src="file.mp4" type="video/mp4">` .

Instead of having the videos in the root folder, a `media` folder seems better.